### PR TITLE
regen: Added support for *.regen global files

### DIFF
--- a/src/Regen.Core/Builtins/CommonLinq.cs
+++ b/src/Regen.Core/Builtins/CommonLinq.cs
@@ -8,7 +8,7 @@ using Regen.DataTypes;
 namespace Regen.Builtins {
     public static class CommonLinq {
         public static Array Except(IList @this, params object[] objs) {
-            return Array.Create(@this.Cast<object>().Except(objs));
+            return Array.Create(@this.Cast<object>().Where(left => objs.Any(right => !Equals(left, right))));
         }
 
         public static Array Concat(IList @this, params object[] objs) {

--- a/src/Regen.Core/Compiler/RegenCompiler.Compilation.cs
+++ b/src/Regen.Core/Compiler/RegenCompiler.Compilation.cs
@@ -22,6 +22,14 @@ namespace Regen.Compiler {
             //handle global blocks
             var parsed = ExpressionParser.Parse(code);
             Compile(parsed); //and we just ignore outputs, leaving all variables inside the context.
+        }        
+        
+        /// <summary>
+        ///     Compiles the given code and stores the variables in current <see cref="Context"/>.
+        /// </summary>
+        public void CompileGlobal(ParsedCode parsed) {
+            //handle global blocks
+            Compile(parsed); //and we just ignore outputs, leaving all variables inside the context.
         }
 
         public string Compile(ParsedCode code) {

--- a/src/Regen.Core/README.md
+++ b/src/Regen.Core/README.md
@@ -2,7 +2,7 @@
 Regen at its core is a templating engine that uses C#-Python like syntax (`regen-lang`) and is entirely written in C#.<br>
 Its purpose is to replace T4 Templating with intuitive and fast in-code (not in a seperate file) scripting/templating.<br>
 
-Current version: 0.21a<br>
+Current version: 0.23a<br>
 
 ### Getting Started
 Make sure to read our [getting started](TUTORIAL.md) page!

--- a/src/Regen.Core/Regen.Core.csproj
+++ b/src/Regen.Core/Regen.Core.csproj
@@ -25,7 +25,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>0.2.2.%2a</ApplicationVersion>
+    <ApplicationVersion>0.2.3.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>

--- a/src/Regen.Package/ClearCompilationsCommand.cs
+++ b/src/Regen.Package/ClearCompilationsCommand.cs
@@ -105,6 +105,7 @@ namespace Regen {
                 var newLength = txt.EndPoint.AbsoluteCharOffset;
                 textSelection.MoveToAbsoluteOffset(Math.Min(newLength - 1, index));
             } catch (Exception e) {
+                Logger.Log(e);
 #if DEBUG
                 Message($"Failed parsing file...\n" + e);
 #else

--- a/src/Regen.Package/CompileFileCommand.cs
+++ b/src/Regen.Package/CompileFileCommand.cs
@@ -70,14 +70,14 @@ namespace Regen {
             Instance = new CompileFileCommand(package, commandService);
         }
 
-        /// <summary>
-        /// This function is the callback used to execute the command when the menu item is clicked.
-        /// See the constructor to see how the menu item is associated with this function using
-        /// OleMenuCommandService service and MenuCommand class.
-        /// </summary>
-        /// <param name="sender">Event sender.</param>
-        /// <param name="e">Event args.</param>
-        private void Execute(object sender, EventArgs _) {
+    /// <summary>
+    /// This function is the callback used to execute the command when the menu item is clicked.
+    /// See the constructor to see how the menu item is associated with this function using
+    /// OleMenuCommandService service and MenuCommand class.
+    /// </summary>
+    /// <param name="sender">Event sender.</param>
+    /// <param name="e">Event args.</param>
+    private void Execute(object sender, EventArgs _) {
             ThreadHelper.ThrowIfNotOnUIThread();
 
             // open the file in a VS code window and activate the pane
@@ -104,6 +104,7 @@ namespace Regen {
                 ed.Insert(text);
                 textSelection.MoveToAbsoluteOffset(index);
             } catch (Exception e) {
+                Logger.Log(e);
 #if DEBUG
                 Message($"Failed parsing file...\n" + e);
 #else

--- a/src/Regen.Package/CompileSelectionCommand.cs
+++ b/src/Regen.Package/CompileSelectionCommand.cs
@@ -93,7 +93,6 @@ namespace Regen {
                 return;
             }
 
-            var fileCode = txt.GetText().Replace("\r", "");
             TextSelection textSelection = doc.ActiveWindow.Document.Selection as TextSelection;
 
             var cursor = textSelection.ActivePoint as VirtualPoint;
@@ -106,6 +105,7 @@ namespace Regen {
                 ed.Insert(text);
                 textSelection.MoveToAbsoluteOffset(index);
             } catch (Exception e) {
+                Logger.Log(e);
 #if DEBUG
                 Message($"Failed parsing file...\n" + e);
 #else

--- a/src/Regen.Package/Engine/RegenEngine.cs
+++ b/src/Regen.Package/Engine/RegenEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Regen.Compiler;
@@ -10,6 +11,11 @@ namespace Regen.Engine {
     ///     Central class to different types of methods that use <see cref="Regen"/>.
     /// </summary>
     public static class RegenEngine {
+        /// <summary>
+        ///     All global files contents that were found.
+        /// </summary>
+        public static List<string> Globals { get; } = new List<string>();
+
         public static CodeFrame[] Parse(string code) {
             return CodeFrame.Create(code)
                 .Select(frame => Parse(frame, code))
@@ -24,7 +30,7 @@ namespace Regen.Engine {
         public static CodeFrame Parse(CodeFrame frame, string code) {
             var compiler = new RegenCompiler(); //todo modules here?
             var parsedCode = ExpressionParser.Parse(frame.Input);
-
+            LoadGlobals(compiler);
             //handle globals
             var globals = CodeFrame.CreateGlobal(code);
             foreach (var globalFrame in globals) {
@@ -33,7 +39,13 @@ namespace Regen.Engine {
 
             frame.Output = compiler.Compile(parsedCode);
             return frame;
-        }        
+        }
+
+        static void LoadGlobals(RegenCompiler compiler) {
+            foreach (var content in Globals) {
+                compiler.CompileGlobal(content);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Regen.Package/Regen.Package.csproj
+++ b/src/Regen.Package/Regen.Package.csproj
@@ -54,6 +54,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ReloadGlobalsCommand.cs" />
     <Compile Include="ClearCompilationsCommand.cs" />
     <Compile Include="ClearCompilationsSelectionCommand.cs" />
     <Compile Include="CompileFileCommand.cs" />
@@ -102,6 +103,9 @@
     </Reference>
     <Reference Include="EnvDTE90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.ApplicationInsights.2.0.1\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.CommandBars, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -178,6 +182,9 @@
     </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="VsixLogger, Version=1.1.44.0, Culture=neutral, PublicKeyToken=29d32695dc822296, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VsixLogger.1.1.44.0\lib\net45\VsixLogger.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\Microsoft.VisualStudio.SDK.Analyzers.15.8.33\analyzers\cs\Microsoft.VisualStudio.SDK.Analyzers.dll" />

--- a/src/Regen.Package/RegenPackage.cs
+++ b/src/Regen.Package/RegenPackage.cs
@@ -69,6 +69,8 @@ namespace Regen {
             // Do any initialization that requires the UI thread after switching to the UI thread.
             await this.JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
+            Logger.Initialize(this, "RegenPackage");
+
             var dir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var files = Directory.GetFiles(dir, "*.exe").Concat(Directory.GetFiles(dir, "*.dll")).ToArray();
             Debug.Print($"Loading assembilies for Regen:\n{dir}\n{string.Join("\n", files)}");
@@ -95,6 +97,8 @@ namespace Regen {
             await ClearCompilationsCommand.InitializeAsync(this);
 
             await ClearCompilationsSelectionCommand.InitializeAsync(this);
+
+            await ReloadGlobalsCommand.InitializeAsync(this);
         }
 
         #endregion

--- a/src/Regen.Package/RegenPackage.vsct
+++ b/src/Regen.Package/RegenPackage.vsct
@@ -49,6 +49,13 @@
           <ButtonText>Clear At Cursor</ButtonText>
         </Strings>
       </Button>
+
+      <Button guid="guidRegenPackageCmdSet" id="ReloadGlobals" priority="0x0100" type="Button">
+        <Parent guid="guidRegenPackageCmdSet" id="MyMenuGroup" />
+        <Strings>
+          <ButtonText>Reload Globals</ButtonText>
+        </Strings>
+      </Button>
     </Buttons>
 
     <!--The bitmaps section is used to define the bitmaps that are used for the commands.-->
@@ -71,6 +78,7 @@
       <IDSymbol name="CompileSelection" value="0x0102" />
       <IDSymbol name="ClearCompilations" value="0x0103" />
       <IDSymbol name="ClearCompilationsSelection" value="0x0104" />
+      <IDSymbol name="ReloadGlobals" value="0x0105" />
       <IDSymbol name="TopLevelMenu" value="0x1021" />
     </GuidSymbol>
 

--- a/src/Regen.Package/ReloadGlobalsCommand.cs
+++ b/src/Regen.Package/ReloadGlobalsCommand.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.ComponentModel.Design;
-using System.Linq;
+using System.IO;
 using System.Media;
 using System.Text.RegularExpressions;
 using EnvDTE;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Regen.Compiler;
+using Regen.Engine;
 using Regen.Helpers;
 using Regen.Parser;
 using Task = System.Threading.Tasks.Task;
@@ -15,11 +16,11 @@ namespace Regen {
     /// <summary>
     /// Command handler
     /// </summary>
-    internal sealed class ClearCompilationsSelectionCommand {
+    internal sealed class ReloadGlobalsCommand {
         /// <summary>
         /// Command ID.
         /// </summary>
-        public const int CommandId = 0x0104;
+        public const int CommandId = 0x0105;
 
         /// <summary>
         /// Command menu group (command set GUID).
@@ -37,19 +38,20 @@ namespace Regen {
         /// </summary>
         /// <param name="package">Owner package, not null.</param>
         /// <param name="commandService">Command service to add command to, not null.</param>
-        private ClearCompilationsSelectionCommand(AsyncPackage package, OleMenuCommandService commandService) {
+        private ReloadGlobalsCommand(AsyncPackage package, OleMenuCommandService commandService) {
             this.package = package ?? throw new ArgumentNullException(nameof(package));
             commandService = commandService ?? throw new ArgumentNullException(nameof(commandService));
 
             var menuCommandID = new CommandID(CommandSet, CommandId);
             var menuItem = new MenuCommand(this.Execute, menuCommandID);
             commandService.AddCommand(menuItem);
+            Execute(null, null);
         }
 
         /// <summary>
         /// Gets the instance of the command.
         /// </summary>
-        public static ClearCompilationsSelectionCommand Instance { get; private set; }
+        public static ReloadGlobalsCommand Instance { get; private set; }
 
         /// <summary>
         /// Gets the service provider from the owner package.
@@ -68,7 +70,7 @@ namespace Regen {
             await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync(package.DisposalToken);
 
             OleMenuCommandService commandService = await package.GetServiceAsync((typeof(IMenuCommandService))) as OleMenuCommandService;
-            Instance = new ClearCompilationsSelectionCommand(package, commandService);
+            Instance = new ReloadGlobalsCommand(package, commandService);
         }
 
         /// <summary>
@@ -84,41 +86,28 @@ namespace Regen {
             // open the file in a VS code window and activate the pane
             DTE dte = Package.GetGlobalService(typeof(DTE)) as DTE;
             Document doc = dte?.ActiveDocument;
+            string solutionDir = System.IO.Path.GetDirectoryName(dte.Solution.FullName);
 
-            TextDocument txt = doc?.Object() as TextDocument;
-            if (dte == null || doc == null || txt == null) {
-                SystemSounds.Beep.Play();
+            Logger.Log("Searching for *.regen files at: "+solutionDir);
+            var files = Directory.GetFiles(solutionDir, "*.regen", SearchOption.AllDirectories);
+            if (files.Length == 0)
                 return;
-            }
 
-            TextSelection textSelection = doc.ActiveWindow.Document.Selection as TextSelection;
-            var cursor = textSelection.ActivePoint as VirtualPoint;
-            var index = cursor.AbsoluteCharOffset;
+            RegenEngine.Globals.Clear(); //clear existing.
 
-            var code = txt.GetText().Replace("\r", "");
-            var matches = Regex.Matches(code, $@"(\#if\s{Regexes.DefineMarker}[\n\r]{{1,2}}    [\s|\S]*?    \#else[\n\r]{{1,2}} )  ([\s|\S]*?)   (?=\#endif)", Regexes.DefaultRegexOptions);
-            var match = matches.Cast<Match>().FirstOrDefault(m => m.DoesMatchNests(index));
-            if (match == null) {
-                SystemSounds.Beep.Play();
-                return;
-            }
+            foreach (var file in files) {
+                Logger.Log($"Loading globals from {file}");
 
-            code = code.RemoveStringBetween("#else", "#endif", Math.Max(match.Index - 1, 0)).Replace("#else#endif", "#else" +Environment.NewLine+ Environment.NewLine + "#endif");
-            try {
-                var ed = txt.CreateEditPoint(txt.StartPoint);
-                ed.Delete(txt.EndPoint);
-                ed.Insert(code);
-                var newLength = txt.EndPoint.AbsoluteCharOffset;
-                textSelection.MoveToAbsoluteOffset(Math.Min(newLength - 1, index));
-
-                textSelection.MoveToAbsoluteOffset(Math.Min(newLength - 1, match.Groups[2].Index));
-            } catch (Exception e) {
-                Logger.Log(e);
-#if DEBUG
-                Message($"Failed parsing file...\n" + e);
-#else
-                Message($"Failed parsing file...\n" + e.Message + "\n" + e.InnerException?.Message);
-#endif
+                try {
+                    var content = File.ReadAllText(file);
+                    var compiler = new RegenCompiler();
+                    compiler.CompileGlobal(content); //just compile to see if it is compilable.
+                    RegenEngine.Globals.Add(content);
+                } catch (Exception e) {
+                    Logger.Log($"Failed parsing \"{file}\", stopping load...");
+                    Logger.Log(e);
+                    break;
+                }
             }
 
             // now set the cursor to the beginning of the function
@@ -127,7 +116,7 @@ namespace Regen {
                 // Show a message box to prove we were here
                 VsShellUtilities.ShowMessageBox(
                     this.package,
-                    msg, //$"index: {pt.AbsoluteCharOffset}, path: {doc.FullName}\n+{textSelection.Text.Length}",
+                    msg,
                     "Regen",
                     OLEMSGICON.OLEMSGICON_INFO,
                     OLEMSGBUTTON.OLEMSGBUTTON_OK,

--- a/src/Regen.Package/packages.config
+++ b/src/Regen.Package/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.ApplicationInsights" version="2.0.1" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.CoreUtility" version="15.0.26228" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging" version="15.0.26228" targetFramework="net46" />
   <package id="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime" version="14.3.25408" targetFramework="net46" />
@@ -28,4 +29,5 @@
   <package id="System.Reflection.Emit.ILGeneration" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="VsixLogger" version="1.1.44.0" targetFramework="net46" />
 </packages>

--- a/src/Regen.Package/releases/CHANGELOG.MD
+++ b/src/Regen.Package/releases/CHANGELOG.MD
@@ -1,6 +1,6 @@
 #### 0.22a
-- added forevery(IList,IList, bool)
-- added forevery(IList,IList, IList, bool)
+- added `forevery(IList,IList, bool)`
+- added `forevery(IList,IList, IList, bool)`
 - fixed extra newline at the beggining of an output after every compile.
 
 #### 0.21a stable

--- a/src/Regen.Package/source.extension.vsixmanifest
+++ b/src/Regen.Package/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Regen.Package.c7e6e38d-0855-40ae-9d99-35f9fd2e5c25" Version="0.22" Language="en-US" Publisher="Eli Belash" />
+        <Identity Id="Regen.Package.c7e6e38d-0855-40ae-9d99-35f9fd2e5c25" Version="0.23" Language="en-US" Publisher="Eli Belash" />
         <DisplayName>Regen.Package</DisplayName>
         <Description xml:space="preserve">Regen is a tool that aims to replace messy and unmaintainable T4 generators with in-code generating.</Description>
         <Icon>https://avatars3.githubusercontent.com/u/44989469?s=200&amp;v=4</Icon>
@@ -9,14 +9,14 @@
         <Tags>T4 Code Generate Generator Template Templating</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0, 16.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0, 17.0)" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0]" />
+        <Dependency Id="Microsoft.VisualStudio.MPF.15.0" DisplayName="Visual Studio MPF 15.0" d:Source="Installed" Version="[15.0,17.0)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.8.27729.1,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />

--- a/test/Regen.Core.UnitTest/Expression/BuiltinTests.cs
+++ b/test/Regen.Core.UnitTest/Expression/BuiltinTests.cs
@@ -146,5 +146,23 @@ namespace Regen.Core.Tests.Expression {
                     3=4
                     3=5");
         }
+
+        [TestMethod]
+        public void forevery_with_exclusion_ofstring() {
+            var @input = $@"
+                %foreach forevery([1,2,3],[3,4,5],true)%
+                    #1=#2
+                %
+                ";
+            Compile(@input).Output.Should().Contain(
+                @"1=3
+                    1=4
+                    1=5
+                    2=3
+                    2=4
+                    2=5
+                    3=4
+                    3=5");
+        }
     }
 }


### PR DESCRIPTION
- Upped version to 0.23a
- Added support for .regen files which are preloaded during initialization or can be reloaded from Regen menu.
- Added logging to output window.
- Added support for VS 2015 and VS 2019, testing required.