### PR TITLE
ISSUE-7 - Static modules do not generate static classes

### DIFF
--- a/src/CodeMinion.Core/CodeGenerator.cs
+++ b/src/CodeMinion.Core/CodeGenerator.cs
@@ -898,7 +898,7 @@ namespace CodeMinion.Core
             s.AppendLine($"namespace {NameSpace}");
             s.Block(() =>
             {
-                s.Out($"public partial class {StaticModuleName}", () =>
+                s.Out($"public static partial class {StaticModuleName}", () =>
                 {
                     s.Break();
                     s.Out("public static PyObject self => _lazy_self.Value;");

--- a/src/Numpy.Bare/np.module.gen.cs
+++ b/src/Numpy.Bare/np.module.gen.cs
@@ -13,7 +13,7 @@ using Numpy.Models;
 
 namespace Numpy
 {
-    public partial class np
+    public static partial class np
     {
         
         public static PyObject self => _lazy_self.Value;

--- a/src/Numpy/np.module.gen.cs
+++ b/src/Numpy/np.module.gen.cs
@@ -14,7 +14,7 @@ using Python.Included;
 
 namespace Numpy
 {
-    public partial class np
+    public static partial class np
     {
         
         public static PyObject self => _lazy_self.Value;

--- a/src/Torch/torch.module.gen.cs
+++ b/src/Torch/torch.module.gen.cs
@@ -13,7 +13,7 @@ using Numpy.Models;
 
 namespace Torch
 {
-    public partial class torch
+    public static partial class torch
     {
         
         public static PyObject self => _lazy_self.Value;


### PR DESCRIPTION
Solves #7 

As discussed in #7, the classes in the following files are now `static`:
- `src\Numpy.Bare\np.module.gen.cs`
- `src\Numpy\np.module.gen.cs`
- `src\Torch\torch.module.gen.cs`

Notes:
I cannot build `Numpy.Bare` :
```
Severity	Code	Description	Project	File	Line	Suppression State
Error	CS1503	Argument 1: cannot convert from '(Numpy.NDarray<int>, Numpy.NDarray)' to 'NDarray[]'	Numpy.Bare.UnitTest	codeminion\test\Numpy.UnitTest\NumPy_array_manipulation.tests.cs	980	Active
```

I think it has to do with this manual addition of `concatenate` in https://github.com/SciSharp/Numpy.NET/commit/766dd522a25af8761179a09beb83a62a296f7389